### PR TITLE
Added support for Header only extraction

### DIFF
--- a/FJExample/Page.xaml.cs
+++ b/FJExample/Page.xaml.cs
@@ -84,7 +84,7 @@ namespace FJExample
             {
                 // After the resize, we can now inspect the PPI values
                 var ppiX = jpegOut.Image.DensityX;
-                var ppiY = jpegOut.Image.DensityX;
+                var ppiY = jpegOut.Image.DensityY;
                 Debug.WriteLine("DPI: {0}, {1}", ppiX, ppiY);
 
                 // We can now also update the DPI


### PR DESCRIPTION
Have added a new public method that allows just the JPEG headers to to be extracted from the file - it's a cut down version of the existing decode method. This is useful when the image is large and is going to be cropped or otherwise manipulated using a BitmapImage or WriteableBitmap, and the user doesn't want the full decode overhead and time. Makes it easy to re-inject the headers when encoding post image processing

Also, there is a single char fix in the demo that I managed to put in this request that should have been a separate request. Sorry